### PR TITLE
fix: require authentication and mail permissions on preview and attachment routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.phpunit.cache
 .phpunit.result.cache
 .vscode
 build

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Optionally, you can publish the views using
 php artisan vendor:publish --tag="mails-views"
 ```
 
-Add the routes to the PanelProvider using the `routes()` method, like this:
+Add the routes to the PanelProvider using the `authenticatedRoutes()` method, like this:
 
 ```php
 use Backstage\Mails\Facades\Mails;
@@ -68,9 +68,16 @@ use Backstage\Mails\Facades\Mails;
 public function panel(Panel $panel): Panel
 {
     return $panel
-        ->routes(fn () => Mails::routes());
+        ->authenticatedRoutes(fn () => Mails::routes());
 }
 ```
+
+> [!NOTE]
+> `authenticatedRoutes()` registers the routes inside the panel's authentication
+> middleware. The preview and attachment routes also enforce authentication and
+> the `canManageMails()` check themselves, so they stay protected even if you
+> register them with `routes()` — but `authenticatedRoutes()` is the correct
+> place for them.
 
 Then add the plugin to your `PanelProvider`
 
@@ -116,9 +123,14 @@ $panel
 
 This example demonstrates how to combine role-based and permission-based access control, providing a more robust and flexible approach to managing access to mail resources.
 
+The `canManageMails()` check also guards the mail preview and attachment download
+routes. Unauthenticated visitors are redirected to the panel login, authenticated
+users without permission receive a 403, and attachments are only served through
+the mail record they belong to.
+
 ### Tenant middleware and route protection
 
-If you want to protect the mail routes with your (tenant) middleware, you can do so by adding the routes to the `tenantRoutes`:
+If you want to protect the mail routes with your (tenant) middleware, you can do so by adding the routes to the `authenticatedTenantRoutes`:
 
 ```php
 use Backstage\Mails\MailsPlugin;
@@ -128,7 +140,7 @@ public function panel(Panel $panel): Panel
 {
     return $panel
         ->plugin(MailsPlugin::make())
-        ->tenantRoutes(fn() => Mails::routes());
+        ->authenticatedTenantRoutes(fn () => Mails::routes());
 }
 ```
 

--- a/src/Controllers/MailDownloadController.php
+++ b/src/Controllers/MailDownloadController.php
@@ -2,24 +2,19 @@
 
 namespace Backstage\Mails\Controllers;
 
-use Backstage\Mails\Laravel\Models\MailAttachment;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Config;
 
 class MailDownloadController extends Controller
 {
-    public function __invoke(...$arguments)
+    public function __invoke(Request $request)
     {
-        if (count($arguments) === 4) {
-            [$tenant, $mail, $attachment, $filename] = $arguments;
-        } else {
-            [$mail, $attachment, $filename] = $arguments;
-            $tenant = null;
-        }
+        $mailModel = Config::get('mails.models.mail');
 
-        $attachmentModel = Config::get('mails.models.attachment');
-        /** @var MailAttachment $attachment */
-        $attachment = $attachmentModel::find($attachment);
+        $mail = $mailModel::findOrFail($request->route('mail'));
+
+        $attachment = $mail->attachments()->findOrFail($request->route('attachment'));
 
         return $attachment->downloadFileFromStorage();
     }

--- a/src/Controllers/MailPreviewController.php
+++ b/src/Controllers/MailPreviewController.php
@@ -2,17 +2,22 @@
 
 namespace Backstage\Mails\Controllers;
 
-use Backstage\Mails\Laravel\Models\Mail;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Config;
 
 class MailPreviewController extends Controller
 {
     public function __invoke(Request $request)
     {
-        /** @var Mail $mail */
-        $mail = Mail::find($request->mail);
+        $mailModel = Config::get('mails.models.mail');
 
-        return response($mail->html);
+        $mail = $mailModel::findOrFail($request->route('mail'));
+
+        return response($mail->html, 200, [
+            'Content-Type' => 'text/html; charset=UTF-8',
+            'X-Content-Type-Options' => 'nosniff',
+            'Content-Security-Policy' => "frame-ancestors 'self'",
+        ]);
     }
 }

--- a/src/Http/Middleware/EnsureUserCanManageMails.php
+++ b/src/Http/Middleware/EnsureUserCanManageMails.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Backstage\Mails\Http\Middleware;
+
+use Backstage\Mails\MailsPlugin;
+use Closure;
+use Filament\Facades\Filament;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserCanManageMails
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $panel = Filament::getCurrentPanel();
+
+        abort_if($panel === null || ! $panel->hasPlugin('mails'), 403);
+
+        abort_unless(MailsPlugin::get()->userCanManageMails(), 403);
+
+        return $next($request);
+    }
+}

--- a/src/Mails.php
+++ b/src/Mails.php
@@ -4,13 +4,23 @@ namespace Backstage\Mails;
 
 use Backstage\Mails\Controllers\MailDownloadController;
 use Backstage\Mails\Controllers\MailPreviewController;
+use Backstage\Mails\Http\Middleware\EnsureUserCanManageMails;
+use Filament\Http\Middleware\Authenticate;
 use Illuminate\Support\Facades\Route;
 
 class Mails
 {
     public static function routes(): void
     {
-        Route::get('mails/{mail}/preview', MailPreviewController::class)->name('mails.preview');
-        Route::get('mails/{mail}/attachment/{attachment}/{filename}', MailDownloadController::class)->name('mails.attachment.download');
+        Route::middleware([
+            Authenticate::class,
+            EnsureUserCanManageMails::class,
+        ])->group(function (): void {
+            Route::get('mails/{mail}/preview', MailPreviewController::class)
+                ->name('mails.preview');
+
+            Route::get('mails/{mail}/attachment/{attachment}/{filename}', MailDownloadController::class)
+                ->name('mails.attachment.download');
+        });
     }
 }

--- a/tests/Fixtures/TestPanelProvider.php
+++ b/tests/Fixtures/TestPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace Backstage\Mails\Tests\Fixtures;
 
+use Backstage\Mails\Mails;
 use Backstage\Mails\MailsPlugin;
 use Filament\Panel;
 use Filament\PanelProvider;
@@ -14,7 +15,10 @@ class TestPanelProvider extends PanelProvider
             ->default()
             ->id('admin')
             ->path('admin')
+            ->login()
+            ->authGuard('web')
             ->topNavigation()
+            ->routes(fn () => Mails::routes())
             ->plugin(MailsPlugin::make());
     }
 }

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Backstage\Mails\Tests\Fixtures;
+
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable implements FilamentUser
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return true;
+    }
+}

--- a/tests/MailRouteSecurityTest.php
+++ b/tests/MailRouteSecurityTest.php
@@ -72,3 +72,78 @@ it('allows a permitted user to preview a mail', function () {
         ->assertOk()
         ->assertSee('secret');
 });
+
+it('redirects a guest away from an attachment download', function () {
+    Storage::fake('local');
+
+    $mail = Mail::factory()->create();
+    $attachment = attachmentFor($mail);
+
+    $this->get(downloadUrl($mail, $attachment))
+        ->assertRedirect(route('filament.admin.auth.login'));
+});
+
+it('does not serve an attachment belonging to a different mail', function () {
+    Storage::fake('local');
+
+    $mail = Mail::factory()->create();
+    $otherMail = Mail::factory()->create();
+    $attachmentOfOtherMail = attachmentFor($otherMail, 'secret.pdf');
+
+    MailsPlugin::get()->canManageMails(true);
+
+    $this->actingAs(mailUser())
+        ->get(downloadUrl($mail, $attachmentOfOtherMail))
+        ->assertNotFound();
+});
+
+it('serves an attachment that belongs to the mail', function () {
+    Storage::fake('local');
+
+    $mail = Mail::factory()->create();
+    $attachment = attachmentFor($mail, 'invoice.pdf', 'INVOICE BODY');
+
+    MailsPlugin::get()->canManageMails(true);
+
+    $response = $this->actingAs(mailUser())
+        ->get(downloadUrl($mail, $attachment))
+        ->assertOk();
+
+    expect($response->streamedContent())->toBe('INVOICE BODY');
+});
+
+it('returns 404 for an unknown attachment', function () {
+    Storage::fake('local');
+
+    $mail = Mail::factory()->create();
+
+    MailsPlugin::get()->canManageMails(true);
+
+    $url = route('filament.admin.mails.attachment.download', [
+        'mail' => $mail->id,
+        'attachment' => 99999,
+        'filename' => 'nope.pdf',
+    ]);
+
+    $this->actingAs(mailUser())->get($url)->assertNotFound();
+});
+
+it('returns 404 for an unknown mail preview', function () {
+    MailsPlugin::get()->canManageMails(true);
+
+    $url = route('filament.admin.mails.preview', ['mail' => 99999]);
+
+    $this->actingAs(mailUser())->get($url)->assertNotFound();
+});
+
+it('sends hardening headers with the preview', function () {
+    $mail = Mail::factory()->create(['html' => '<p>secret</p>']);
+
+    MailsPlugin::get()->canManageMails(true);
+
+    $this->actingAs(mailUser())
+        ->get(previewUrl($mail))
+        ->assertOk()
+        ->assertHeader('X-Content-Type-Options', 'nosniff')
+        ->assertHeader('Content-Security-Policy', "frame-ancestors 'self'");
+});

--- a/tests/MailRouteSecurityTest.php
+++ b/tests/MailRouteSecurityTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Backstage\Mails\Laravel\Models\Mail;
+use Backstage\Mails\MailsPlugin;
 use Backstage\Mails\Tests\Fixtures\User;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -49,4 +50,25 @@ it('redirects a guest away from the mail preview', function () {
 
     $this->get(previewUrl($mail))
         ->assertRedirect(route('filament.admin.auth.login'));
+});
+
+it('forbids an authenticated user without mail permissions', function () {
+    $mail = Mail::factory()->create(['html' => '<p>secret</p>']);
+
+    MailsPlugin::get()->canManageMails(false);
+
+    $this->actingAs(mailUser())
+        ->get(previewUrl($mail))
+        ->assertForbidden();
+});
+
+it('allows a permitted user to preview a mail', function () {
+    $mail = Mail::factory()->create(['html' => '<p>secret</p>']);
+
+    MailsPlugin::get()->canManageMails(true);
+
+    $this->actingAs(mailUser())
+        ->get(previewUrl($mail))
+        ->assertOk()
+        ->assertSee('secret');
 });

--- a/tests/MailRouteSecurityTest.php
+++ b/tests/MailRouteSecurityTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Backstage\Mails\Laravel\Models\Mail;
+use Backstage\Mails\Tests\Fixtures\User;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+function mailUser(): User
+{
+    return User::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+}
+
+function attachmentFor(Mail $mail, string $filename = 'invoice.pdf', string $contents = 'CONFIDENTIAL')
+{
+    $attachment = $mail->attachments()->create([
+        'uuid' => (string) Str::uuid(),
+        'disk' => 'local',
+        'filename' => $filename,
+        'mime' => 'application/pdf',
+        'inline' => false,
+        'size' => strlen($contents),
+    ]);
+
+    Storage::disk('local')->put($attachment->storagePath, $contents);
+
+    return $attachment;
+}
+
+function previewUrl(Mail $mail): string
+{
+    return route('filament.admin.mails.preview', ['mail' => $mail->id]);
+}
+
+function downloadUrl(Mail $mail, $attachment): string
+{
+    return route('filament.admin.mails.attachment.download', [
+        'mail' => $mail->id,
+        'attachment' => $attachment->id,
+        'filename' => $attachment->filename,
+    ]);
+}
+
+it('redirects a guest away from the mail preview', function () {
+    $mail = Mail::factory()->create(['html' => '<p>secret</p>']);
+
+    $this->get(previewUrl($mail))
+        ->assertRedirect(route('filament.admin.auth.login'));
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,10 @@
 
 namespace Backstage\Mails\Tests;
 
+use Backstage\Mails\Laravel\MailsServiceProvider as LaravelMailsServiceProvider;
 use Backstage\Mails\MailsServiceProvider;
 use Backstage\Mails\Tests\Fixtures\TestPanelProvider;
+use Backstage\Mails\Tests\Fixtures\User;
 use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
 use BladeUI\Icons\BladeIconsServiceProvider;
 use Filament\Actions\ActionsServiceProvider;
@@ -15,6 +17,9 @@ use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
@@ -45,6 +50,7 @@ class TestCase extends Orchestra
             SupportServiceProvider::class,
             TablesServiceProvider::class,
             WidgetsServiceProvider::class,
+            LaravelMailsServiceProvider::class,
             MailsServiceProvider::class,
             TestPanelProvider::class,
         ];
@@ -53,5 +59,24 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
+        config()->set('auth.providers.users.model', User::class);
+    }
+
+    protected function defineDatabaseMigrations(): void
+    {
+        Schema::create('users', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        $directory = __DIR__ . '/../vendor/backstage/laravel-mails/database/migrations';
+
+        foreach (File::files($directory) as $file) {
+            (include $file->getPathname())->up();
+        }
     }
 }


### PR DESCRIPTION
Fixes #83

## Problem

The stored mail preview and attachment download routes were reachable **without authentication**, and the attachment route never verified that the requested attachment belonged to the mail in the URL.

Anyone able to reach the panel path could read the full HTML body of any logged mail and download any stored attachment by supplying a numeric ID.

### Why authentication was missing

`Mails::routes()` registered two bare routes with no middleware. Filament invokes `$panel->getRoutes()` in `packages/panels/routes/web.php:30`, inside the `$panel->getMiddleware()` group — which is only `panel:{id}` plus the panel's web middleware. The `$panel->getAuthMiddleware()` group does not open until line 58.

`->tenantRoutes()` has the same problem: it is invoked at line 191, in a group that applies `getTenantMiddleware()` but sits outside the auth group as well.

Both of these were what the README documented, so installs following the README were exposed. Only `->authenticatedRoutes()` and `->authenticatedTenantRoutes()` sit inside the auth group.

### Why authorization was missing

`MailsPlugin::userCanManageMails()` was wired into every Resource, Page and Widget, but neither controller consulted it.

### Why any attachment resolved under any mail

`MailDownloadController` destructured `{mail}` out of the URL and then never used it:

```php
$attachment = $attachmentModel::find($attachment);

return $attachment->downloadFileFromStorage();
```

## Fix

**Access control is attached inside `Mails::routes()` itself**, rather than left to the consumer's `PanelProvider`:

```php
Route::middleware([
    Authenticate::class,
    EnsureUserCanManageMails::class,
])->group(function (): void {
    // ...
});
```

This was deliberate. A documentation-only fix would leave every existing install vulnerable until they edited their own `PanelProvider`. Attaching the middleware where the routes are defined means the protection travels with them, whichever registration method the consumer picked.

Reusing Filament's own `Authenticate` gives us the panel's configured guard, the redirect to the panel login URL, and the `FilamentUser::canAccessPanel()` check, with behaviour identical to every other page in the panel.

The new `EnsureUserCanManageMails` middleware guards on `$panel->hasPlugin('mails')` before calling `MailsPlugin::get()` — that call resolves through `filament('mails')` and throws when the plugin is absent from the current panel, which would otherwise be a 500 rather than a 403.

**Attachments are now scoped through their mail:**

```php
$mail = $mailModel::findOrFail($request->route('mail'));

$attachment = $mail->attachments()->findOrFail($request->route('attachment'));
```

`Mail::attachments()` is a `HasMany`, so an unrelated attachment ID fails the query and raises a 404 — the file is never read. This also removes the `...$arguments` splat and its `count($arguments) === 4` tenant branch; named route parameters resolve identically with and without a `{tenant}` segment, and the variadic signature is what made it easy to silently drop `{mail}` in the first place.

The `{filename}` segment stays unused on purpose: `downloadFileFromStorage()` builds the storage path from `$this->filename` on the model, so the URL segment never reaches the filesystem.

**Preview hardening:** `find()` → `findOrFail()` (an unknown ID was previously a 500 from `null->html`), the model is resolved from `config('mails.models.mail')` like the download controller, and the response now sends `X-Content-Type-Options: nosniff` and `Content-Security-Policy: frame-ancestors 'self'`. The body is still served verbatim — the preview iframe needs it, and it is same-origin so `frame-ancestors 'self'` permits it.

## Behaviour

| Case | Before | After |
| --- | --- | --- |
| Guest | **200 + mail body** | 302 → panel login |
| Authenticated, `canAccessPanel()` false | 200 | 403 |
| Authenticated, `canManageMails()` false | 200 | 403 |
| Unknown mail ID | 500 | 404 |
| Attachment belonging to a different mail | **200 + file contents** | 404 |
| Unknown attachment ID | 500 | 404 |
| Permitted user, matching pair | 200 | 200 |

## Tests

The existing suite was unit-style with no database or authentication, so this adds the scaffolding for it:

- `TestCase` now registers `Backstage\Mails\Laravel\MailsServiceProvider` — Testbench does not load it automatically, and without it `config('mails.models.mail')` is `null`.
- `defineDatabaseMigrations()` creates a `users` table and runs the laravel-mails migration stubs, which ship as `.php.stub` and are never auto-loaded.
- `tests/Fixtures/User.php` is an authenticatable `FilamentUser`.

`tests/MailRouteSecurityTest.php` covers every row of the table above. Note that the test panel registers the routes with **`->routes()`** — the vulnerable method — on purpose, so the tests prove the middleware protects that path rather than only proving `authenticatedRoutes()` works.

13 tests, 25 assertions, all passing.

## Docs

README now documents `authenticatedRoutes()` / `authenticatedTenantRoutes()`, with a note that the routes enforce the permission themselves regardless.

## Not addressed here

- **Mail enumeration.** The routes are still keyed by sequential numeric IDs, so a permitted user can walk the ID space. Arguably intended for an admin mail log.
- **Tenant scoping.** The `Mail` model has no tenant relation to scope by; `{tenant}` is only a URL segment. With `authenticatedTenantRoutes()` your own tenant middleware handles isolation. Worth a separate issue if cross-tenant access matters.
- **HTML sanitisation.** Mail bodies render verbatim; sanitising would change what admins see versus what the recipient received. The response headers are the mitigation.

## Unrelated issues noticed

- `composer analyse` cannot run — `phpstan` is not in `require-dev`, and `phpstan.neon.dist` uses `checkOctaneCompatibility` / `checkModelProperties`, which were removed in PHPStan 2 / Larastan 3. The PHPStan workflow is therefore broken independently of this PR. Verified locally against an equivalent ad-hoc config: this branch introduces no new errors and removes two.
- `MailAttachmentFactory` in `backstage/laravel-mails` is broken — its `definition()` returns `type`/`ip`/`hostname`/`payload`, none of which are columns on `mail_attachments`. The tests create attachments through the relation instead.

Reported by Ahmet Akdas (Digital Impact).
